### PR TITLE
Code simplification

### DIFF
--- a/font_fallback.xml
+++ b/font_fallback.xml
@@ -88,98 +88,15 @@
 <familyset>
     <!-- first font is default -->
     <family name="sans-serif">
-        <font weight="100" style="normal">InterVariable.ttf
-          <axis tag="opsz" stylevalue="18.0" />
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="100" />
+        <font supportedAxes="wght">InterVariable.ttf
+            <axis tag="opsz" stylevalue="18.0" />
+            <axis tag="wdth" stylevalue="100" />
         </font>
-        <font weight="200" style="normal">InterVariable.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="200" />
+        <font style="italic" supportedAxes="wght">InterVariable-Italic.ttf
+            <axis tag="opsz" stylevalue="18.0" />
+            <axis tag="wdth" stylevalue="100" />
         </font>
-        <font weight="300" style="normal">InterVariable.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="300" />
-        </font>
-        <font weight="400" style="normal">InterVariable.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="400" />
-        </font>
-        <font weight="500" style="normal">InterVariable.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="500" />
-        </font>
-        <font weight="600" style="normal">InterVariable.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="600" />
-        </font>
-        <font weight="700" style="normal">InterVariable.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="700" />
-        </font>
-        <font weight="800" style="normal">InterVariable.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="800" />
-        </font>
-        <font weight="900" style="normal">InterVariable.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="900" />
-        </font>
-        <font weight="100" style="italic">InterVariable-Italic.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="100" />
-        </font>
-        <font weight="200" style="italic">InterVariable-Italic.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="200" />
-        </font>
-        <font weight="300" style="italic">InterVariable-Italic.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="300" />
-        </font>
-        <font weight="400" style="italic">InterVariable-Italic.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="400" />
-        </font>
-        <font weight="500" style="italic">InterVariable-Italic.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="500" />
-        </font>
-        <font weight="600" style="italic">InterVariable-Italic.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="600" />
-        </font>
-        <font weight="700" style="italic">InterVariable-Italic.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="700" />
-        </font>
-        <font weight="800" style="italic">InterVariable-Italic.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="800" />
-        </font>
-        <font weight="900" style="italic">InterVariable-Italic.ttf
-          <axis tag="opsz" stylevalue="18.0"/>
-          <axis tag="wdth" stylevalue="100" />
-          <axis tag="wght" stylevalue="900" />
-        </font>
-   </family>
-
+    </family>
 
     <!-- Note that aliases must come after the fonts they reference. -->
     <alias name="sans-serif-thin" to="sans-serif" weight="100" />
@@ -192,95 +109,13 @@
     <alias name="verdana" to="sans-serif" />
 
     <family name="sans-serif-condensed">
-      <font weight="100" style="normal">InterVariable.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="100" />
+      <font supportedAxes="wght">InterVariable.ttf
+          <axis tag="opsz" stylevalue="18.0" />
+          <axis tag="wdth" stylevalue="75" />
       </font>
-      <font weight="200" style="normal">InterVariable.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="200" />
-      </font>
-      <font weight="300" style="normal">InterVariable.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="300" />
-      </font>
-      <font weight="400" style="normal">InterVariable.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="400" />
-      </font>
-      <font weight="500" style="normal">InterVariable.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="500" />
-      </font>
-      <font weight="600" style="normal">InterVariable.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="600" />
-      </font>
-      <font weight="700" style="normal">InterVariable.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="700" />
-      </font>
-      <font weight="800" style="normal">InterVariable.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="800" />
-      </font>
-      <font weight="900" style="normal">InterVariable.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="900" />
-      </font>
-      <font weight="100" style="italic">InterVariable-Italic.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="100" />
-      </font>
-      <font weight="200" style="italic">InterVariable-Italic.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="200" />
-      </font>
-      <font weight="300" style="italic">InterVariable-Italic.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="300" />
-      </font>
-      <font weight="400" style="italic">InterVariable-Italic.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="400" />
-      </font>
-      <font weight="500" style="italic">InterVariable-Italic.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="500" />
-      </font>
-      <font weight="600" style="italic">InterVariable-Italic.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="600" />
-      </font>
-      <font weight="700" style="italic">InterVariable-Italic.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="700" />
-      </font>
-      <font weight="800" style="italic">InterVariable-Italic.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="800" />
-      </font>
-      <font weight="900" style="italic">InterVariable-Italic.ttf
-        <axis tag="opsz" stylevalue="18.0"/>
-        <axis tag="wdth" stylevalue="75" />
-        <axis tag="wght" stylevalue="900" />
+      <font style="italic" supportedAxes="wght">InterVariable-Italic.ttf
+          <axis tag="opsz" stylevalue="18.0" />
+          <axis tag="wdth" stylevalue="75" />
       </font>
     </family>
     <alias name="sans-serif-condensed-light" to="sans-serif-condensed" weight="300" />
@@ -335,101 +170,15 @@
         <font weight="700" style="italic">SourceSansPro-BoldItalic.ttf</font>
     </family>
     <alias name="source-sans-pro-semi-bold" to="source-sans-pro" weight="600"/>
-    
-    <!-- fallback font patch for inter -->
+
+    <!-- Roboto will be used as a fallback for characters not supported by Inter.
+         This way, unsupported characters are still displayed with the correct metrics and hints.
+    -->
     <family>
-        <font weight="100" style="normal">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="0"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="100"/>
-        </font>
-        <font weight="100" style="italic">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="1"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="100"/>
-        </font>
-        <font weight="200" style="normal">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="0"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="200"/>
-        </font>
-        <font weight="200" style="italic">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="1"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="200"/>
-        </font>
-        <font weight="300" style="normal">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="0"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="300"/>
-        </font>
-        <font weight="300" style="italic">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="1"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="300"/>
-        </font>
-        <font weight="400" style="normal">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="0"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="400"/>
-        </font>
-        <font weight="400" style="italic">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="1"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="400"/>
-        </font>
-        <font weight="500" style="normal">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="0"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="500"/>
-        </font>
-        <font weight="500" style="italic">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="1"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="500"/>
-        </font>
-        <font weight="600" style="normal">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="0"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="600"/>
-        </font>
-        <font weight="600" style="italic">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="1"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="600"/>
-        </font>
-        <font weight="700" style="normal">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="0"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="700"/>
-        </font>
-        <font weight="700" style="italic">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="1"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="700"/>
-        </font>
-        <font weight="800" style="normal">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="0"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="800"/>
-        </font>
-        <font weight="800" style="italic">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="1"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="800"/>
-        </font>
-        <font weight="900" style="normal">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="0"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="900"/>
-        </font>
-        <font weight="900" style="italic">Roboto-Regular.ttf
-            <axis tag="ital" stylevalue="1"/>
-            <axis tag="wdth" stylevalue="100"/>
-            <axis tag="wght" stylevalue="900"/>
+        <font supportedAxes="wght,ital">Roboto-Regular.ttf
+          <axis tag="wdth" stylevalue="100" />
         </font>
     </family>
-    <!-- fallback font patch for inter end-->
 
     <!-- fallback fonts -->
     <family lang="und-Arab" variant="elegant">


### PR DESCRIPTION
* [As I said in my last PR,](https://github.com/ihfandicahyo/proton-aosp-stuff/pull/3#:~:text=(patching%20fonts%20is%20done%20exactly%20the%20same%20way%2C%20might%20be%20worth%20reconsidering%2C%20but%20it%20works%20for%20now).) it was worth reconsidering the font patching method, as the new [font_fallback](https://github.com/LineageOS/android_frameworks_base/blob/lineage-22.1/data/fonts/font_fallback.xml) primarily uses auto-adjustment, which in turn is supported by Inter and allows us to simplify the code used.
<img src="https://github.com/user-attachments/assets/d2a70964-235c-4465-9f01-46ae3887e570" width="200" height="103">